### PR TITLE
Parse for a module's controllers and display in a subheadder

### DIFF
--- a/template/tmpl/container.tmpl
+++ b/template/tmpl/container.tmpl
@@ -73,12 +73,34 @@
     -->
 
     <?js
-        var classes = self.find({kind: 'class', memberof: doc.longname});
-        if (doc.kind !== 'globalobj' && classes && classes.length) {
+        var controllers = self.find({ngdoc: 'controller', memberof: doc.longname});
+        if (doc.kind !== 'globalobj' && controllers && controllers.length) {
+    ?>
+        <h3 class="subsection-title">Controllers</h3>
+
+        <dl><?js controllers.forEach(function(c) { ?>
+            <dt><?js= self.linkto(c.longname, c.name) ?></dt>
+            <dd><?js if (c.summary) { ?><?js= c.summary ?><?js } ?></dd>
+        <?js }); ?></dl>
+    <?js } ?>
+
+    <?js
+        var classes = self.find({kind: 'class', memberof: doc.longname}) || [];
+          var non_ngdoc_exists = false;
+          classes.every(function(c) {
+            if (!c.ngdoc) {
+              non_ngdoc_exists = true;
+              return false;
+            }
+            return true;
+          });
+          if (doc.kind !== 'globalobj' && classes.length && non_ngdoc_exists) {
     ?>
         <h3 class="subsection-title">Classes</h3>
 
-        <dl><?js classes.forEach(function(c) { ?>
+        <dl><?js classes.forEach(function(c) {
+            if (c.ngdoc) { return; }
+            ?>
             <dt><?js= self.linkto(c.longname, c.name) ?></dt>
             <dd><?js if (c.summary) { ?><?js= c.summary ?><?js } ?></dd>
         <?js }); ?></dl>


### PR DESCRIPTION
Hi, I wanted to be able to list my module's controllers in the sub header area. Currently, there's only a Classes heading, and when you add `@ngdoc controller` to a controller, the @kind variable is set to class. This causes any angularjs controllers to fall under the 'Classes' subheader. 

I added a Controllers subheader and some parsing logic to display any controllers in the correct header level. Any entity that uses the @ngdoc tag will be ignored in the Classes subheader section. I think that's fair since you can still use the @name and @class tags to display static classes of modules if you really wanted to. 

[Here's a link to an example screenshot](http://aressler38.github.io/screenshot-angular-jsdoc-1.png)