### PR TITLE
Adjusts the main content area 

### DIFF
--- a/template/static/styles/jsdoc-default.css
+++ b/template/static/styles/jsdoc-default.css
@@ -118,6 +118,14 @@ nav a:active {
     max-width: 976px;
     margin: 0 auto;
 }
+
+@media only screen and (max-width: 1280px) {
+    #main {
+        max-width: none;
+        margin: 0 221px 0 0;
+    }
+}
+
 footer {
     max-width: 976px;
     margin: 0 auto;


### PR DESCRIPTION
A media query so the `#main` area is not hidden by the TOC in low resolutions. 

Fixes #16 