### PR TITLE
Grunt example had paths that did not work out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Quick Start
           src: ['directives', 'services'],
           options: {
             destination: 'build/docs',
-            configure: 'node_modules/angular-jsdoc/conf.json',
-            template: 'node_modules/angular-jsdoc/template',
+            configure: 'node_modules/angular-jsdoc/common/conf.json',
+            template: 'node_modules/angular-jsdoc/default',
             readme: './README.md'
           }
         }


### PR DESCRIPTION
It took me some time to figure out that the paths given in the grunt-example where not valid. I've updated README.md to reflect the real paths. These are also the paths given in the other examples.