### PR TITLE
the template needs entity escaping

### DIFF
--- a/angular-template/html/class.html
+++ b/angular-template/html/class.html
@@ -115,7 +115,7 @@
                   <tr ht-repeat="param in func.params">
                     <td class="name">{{ param.name }}</td>
                     <td class="type"><span class="param-type">
-                      {{ param.type && param.type.names.join(" | ") }}
+                         {{ param.type && param.type.names.join(" | ").replace(new RegExp( String.fromCharCode(60), "g" ), "&lt;") }}
                     </span></td>
                     <td class="description last">{{ param.description }}</td>
                   </tr>


### PR DESCRIPTION
found a rendering bug if the @param in the source code refers to an array type

```
@param fields {object[]} list of fields
```

the generator needs to have intelligence, perhaps as a common service because this other entities may have < or > in the text

in this case an array of objects will place the text  Array.<object> into the HTML file. Obviously the object tag is actually an HTML5 reserved tag ( and so the page is corrupted ). So either use the fix I provided, or better yet find out which directive can be used to fix this.. I thought ng-safe-html ? but it didn't work for me.