### PR TITLE
added more tag support for angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ Specification
                  Default: 'README.md'
   - callback: callback function with output parameter. e.g., `function(output) {console.log(output)}`
 
+Tags Available
+--------
+- `@ngdoc` - specifies the type of thing being documented. See below for more detail.
+- `@scope` - specifies that the documented directive will create a new scope
+- `@priority` - specifies the documented directive's priority
+- `@animations` - specifies the animations that the documented directive supports
+- `@restrict` - specifies how directives should be shown in the usage section. For example, for [E]lement, [A]ttribute, and [C]lass, use @restrict ECA
+- `@eventType emit|broadcast` - specifies whether the event is emitted or broadcast
+
 Example
 --------
 

--- a/angular-template/html/class.html
+++ b/angular-template/html/class.html
@@ -136,7 +136,7 @@
                   <tr ht-repeat="param in func.params">
                     <td class="name">{{ param.name }}</td>
                     <td class="type"><span class="param-type">
-                      {{ param.type && param.type.names.join(" | ") }}
+                      {{ param.type && param.type.names.join(" | ").replace(new RegExp( String.fromCharCode(60), "g" ), "&lt;") }}
                     </span></td>
                     <td class="description last">{{ param.description }}</td>
                   </tr>

--- a/angular-template/html/class.html
+++ b/angular-template/html/class.html
@@ -5,6 +5,23 @@
           {{ description }}
         </div>
         <div class="details"></div>
+        <div ht-if="newScope">
+          <b>Creates a new scope</b>
+        </div>
+        <div ht-if="restrict">
+            <h5>Restricted on</h5>
+            <ul ht-repeat="rest in restrict">
+                <li>{{rest}}</li>
+            </ul>
+        </div>
+        <div ht-if="priority">
+            <h5>Priority</h5>
+            {{priority}}
+        </div>
+        <div ht-if="eventType">
+            <h5>Event type</h5>
+            {{eventType}}
+        </div>
         <div ht-if="params">
           <h5>Dependencies:</h5>
           <table class="params">
@@ -62,6 +79,10 @@
             <li ht-repeat="el in requires">{{ el }} Service</li>
           </ul>
         </div>
+        <div ht-if="animations">
+          <h5>Animations:</h5>
+          <pre>{{ animations }}</pre>
+        </div>
         <div ht-if="typeof examples !== 'undefined' && examples.length">
           <h5>Example</h5>
           <pre ht-repeat="example in examples" class="prettyprint"><code><span class="str">{{ example.code }}</span></code></pre>
@@ -115,7 +136,7 @@
                   <tr ht-repeat="param in func.params">
                     <td class="name">{{ param.name }}</td>
                     <td class="type"><span class="param-type">
-                         {{ param.type && param.type.names.join(" | ").replace(new RegExp( String.fromCharCode(60), "g" ), "&lt;") }}
+                      {{ param.type && param.type.names.join(" | ") }}
                     </span></td>
                     <td class="description last">{{ param.description }}</td>
                   </tr>

--- a/common/plugins/ngdoc.js
+++ b/common/plugins/ngdoc.js
@@ -21,4 +21,46 @@ exports.defineTags = function(dictionary) {
     }
   })
   .synonym('attr');
+
+  dictionary.defineTag('restrict', {
+    mustHaveValue: true,
+    onTagged: function(doclet, tag) {
+      var restricts={
+          'A': 'Attribute',
+          'E': 'Element',
+          'C': 'Class'
+      }
+      var s = tag.value.split('').map(function(aec) {
+        return restricts[aec];
+      })
+      doclet.restrict = s;
+    }
+  });
+
+  dictionary.defineTag('priority', {
+    mustHaveValue: true,
+    onTagged: function(doclet, tag) {
+      doclet.priority = tag.value;
+    }
+  });
+
+  dictionary.defineTag('eventType', {
+    mustHaveValue: true,
+    onTagged: function(doclet, tag) {
+      doclet.eventType = tag.value;
+    }
+  });
+
+  dictionary.defineTag('animations', {
+    mustHaveValue: true,
+    onTagged: function(doclet, tag) {
+      doclet.animations = tag.value;
+    }
+  });
+
+  dictionary.defineTag('scope', {
+    onTagged: function(doclet, tag) {
+      doclet.newScope = true;
+    }
+  });
 };


### PR DESCRIPTION
Added more tag support for angular documentation. This is based on the documentation found here: https://github.com/angular/angular.js/wiki/Writing-AngularJS-Documentation#angularjs-specific-ngdoc-directives
New tags supported are : @scope, @priority, @animations, @restrict, @eventType