### PR TITLE
Add <meta charset="utf-8"> to the docs headers 

### DIFF
--- a/angular-template/html/layout.html
+++ b/angular-template/html/layout.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <base ht-if="data.code" href="../" />
     <title>JSDoc: {{ title }}</title>
     <link type="text/css" rel="stylesheet" href="css/jsdoc-default.css" />


### PR DESCRIPTION
We're writing the output files using UTF-8 encoding, so charset should be present in HTML.

This will tell the correct encoding to the browser, especially when opening the docs without a web server.

Currently, opening the docs containing non-latin characters (e.g. cyrillic) without a web server (just from FS) results in wrong encoding.