### PR TITLE
Hyperlink JSDoc link references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ nohup.out
 node_modules
 /tmp/
 /out
+.idea/

--- a/angular-template/html/class.html
+++ b/angular-template/html/class.html
@@ -2,7 +2,7 @@
       <dt></dt>
       <dd>
         <div class="description">
-          {{ description }}
+          {{ description.replace(/\{@link (.*)\}/, '<a href="$1.html">$1</a>') }}
         </div>
         <div class="details"></div>
         <div ht-if="newScope">


### PR DESCRIPTION
When using JSDoc’s [`{@link}`](http://usejsdoc.org/tags-inline-link.html) this has been rendered as plain text so far.

I’ve added a regular expression to link to the actual definition in the documentation. So, if you linked like `{@link app.myDirectiveWhichIsMemberOfTheAppModule}` this would replace the text with `app.myDirectiveWhichIsMemberOfTheAppModule` and hyperlink it to the documentation of that directive.

This is for now working for `{@link}` references in ngDoc `@description` tags only. Of course this can just as easily be added to param, method etc. descriptions.
I have a question regarding that. I’ve used a regular expression right within the template as has been done for other issues in the past. I’m wondering if there’s some kind of backing JS file from which functions can be called on the template. As I can see there’s no such thing in the `angular-template` engine that’s being used. I just see the hassle of repeating that regular expression for all the different kinds of descriptions right within the template while it could be easily generalised into a single function.
Would be nice if you gave me some hints on that without me spending time on a lot of reverse engineering and stuff since I have many other ideas for this project in mind.

Thanks for this project, it has been by far the easiest AngularJS documentation generation experience. 👍🏼