### PR TITLE
Enhanced support for JSDoc link references and custom types

### DIFF
--- a/angular-template/html/class.html
+++ b/angular-template/html/class.html
@@ -65,7 +65,11 @@
                     {{ prop.typeDefinitionUrl }}
                   </span>
                 </td>
-                <td class="description last">{{ prop.description }}</td>
+                <td class="description last">
+                  <span ht-if="prop.description">
+                    {{ prop.description.replace(/\{@link (.*?)(#.*?)?\}/g, '<a href="$1.html$2">$1$2</a>') }}
+                  </span>
+                </td>
               </tr>
             </tbody>
           </table>

--- a/angular-template/html/class.html
+++ b/angular-template/html/class.html
@@ -40,7 +40,7 @@
                   {{ param.name }}
                 </td>
                 <td class="type"><span class="param-type">
-                  {{ param.typeDefinition }}
+                  {{ param.typeDefinitionUrl }}
                 </span></td>
                 <td class="description last">
                   <span ht-if="param.description">
@@ -62,7 +62,7 @@
                 <td class="name" nowrap>{{ prop.name }}</td>
                 <td class="type">
                   <span class="param-type">
-                    {{ prop.typeDefinition }}
+                    {{ prop.typeDefinitionUrl }}
                   </span>
                 </td>
                 <td class="description last">{{ prop.description }}</td>
@@ -80,7 +80,7 @@
               <tr ht-repeat="attr in attributes">
                 <td class="name" nowrap>{{ attr.name }}</td>
                 <td class="type"><span class="param-type">
-                  {{ attr.typeDefinition }}
+                  {{ attr.typeDefinitionUrl }}
                 </span></td>
                 <td class="description last">
                   <span ht-if="attr.description">
@@ -147,8 +147,8 @@
               <h4 class="name">
                 {{ func.name }}
                 <span ht-if="func.params" class="signature">({{ func.params.map(function(param){return param.name;}).join(", ") }})</span>
-                <span ht-if="func.returns && func.returns[0].type" class="type-signature">
-                  -&gt; {{ func.returns[0].type.names.join(" | ") }}
+                <span ht-if="func.returns[0].typeDefinition" class="type-signature">
+                  -&gt; {{ func.returns[0].typeDefinition }}
                 </span>
               </h4>
             </a>
@@ -173,7 +173,7 @@
                   <tr ht-repeat="param in func.params">
                     <td class="name">{{ param.name }}</td>
                     <td class="type"><span class="param-type">
-                      {{ param.typeDefinition }}
+                      {{ param.typeDefinitionUrl }}
                     </span></td>
                     <td class="description last">
                       <span ht-if="param.description">
@@ -194,7 +194,7 @@
                   <tr ht-repeat="ret in func.returns">
                     <td class="type">
                       <span class="param-type">
-                        {{ ret.type && ret.type.names.join(" | ").replace(new RegExp( String.fromCharCode(60), "g" ), "&lt;") }}
+                        {{ ret.typeDefinitionUrl }}
                       </span>
                     </td>
                     <td class="description last">

--- a/angular-template/html/class.html
+++ b/angular-template/html/class.html
@@ -40,7 +40,7 @@
                   {{ param.name }}
                 </td>
                 <td class="type"><span class="param-type">
-                  {{ param.type && param.type.names.join(" | ") }}
+                  {{ param.typeDefinition }}
                 </span></td>
                 <td class="description last">
                   <span ht-if="param.description">
@@ -167,7 +167,7 @@
                   <tr ht-repeat="param in func.params">
                     <td class="name">{{ param.name }}</td>
                     <td class="type"><span class="param-type">
-                      {{ param.type && param.type.names.join(" | ").replace(new RegExp( String.fromCharCode(60), "g" ), "&lt;") }}
+                      {{ param.typeDefinition }}
                     </span></td>
                     <td class="description last">
                       <span ht-if="param.description">

--- a/angular-template/html/class.html
+++ b/angular-template/html/class.html
@@ -2,7 +2,7 @@
       <dt></dt>
       <dd>
         <div ht-if="description" class="description">
-          {{ description.replace(/\{@link (.*)\}/, '<a href="$1.html">$1</a>') }}
+          {{ description.replace(/\{@link (.*)\}/g, '<a href="$1.html">$1</a>') }}
         </div>
         <div class="details"></div>
         <div>

--- a/angular-template/html/class.html
+++ b/angular-template/html/class.html
@@ -5,9 +5,12 @@
           {{ description.replace(/\{@link (.*?)(#.*?)?\}/g, '<a href="$1.html$2">$1$2</a>') }}
         </div>
         <div class="details"></div>
-        <div>
-          <div>
-            <h5>{{directiveScope}}</h5>
+        <div ht-if="newScope">
+          <div ht-if="newScope === true">
+            <h5>Creates a new {{scopeType}}</h5>
+          </div>
+          <div ht-if="newScope !== true">
+            <h5>Uses {{scopeType}}</h5>
           </div>
         </div>
         <div ht-if="restrict">

--- a/angular-template/html/class.html
+++ b/angular-template/html/class.html
@@ -2,7 +2,7 @@
       <dt></dt>
       <dd>
         <div ht-if="description" class="description">
-          {{ description.replace(/\{@link (.*)\}/g, '<a href="$1.html">$1</a>') }}
+          {{ description.replace(/\{@link (.*?)(#.*?)?\}/g, '<a href="$1.html$2">$1$2</a>') }}
         </div>
         <div class="details"></div>
         <div>

--- a/angular-template/html/class.html
+++ b/angular-template/html/class.html
@@ -5,12 +5,9 @@
           {{ description.replace(/\{@link (.*)\}/, '<a href="$1.html">$1</a>') }}
         </div>
         <div class="details"></div>
-        <div ht-if="newScope">
-          <div ht-if="newScope === true">
-            <h5>Creates a new {{scopeType}}</h5>
-          </div>
-          <div ht-if="newScope !== true">
-            <h5>Uses {{scopeType}}</h5>
+        <div>
+          <div>
+            <h5>{{directiveScope}}</h5>
           </div>
         </div>
         <div ht-if="restrict">

--- a/angular-template/html/class.html
+++ b/angular-template/html/class.html
@@ -32,11 +32,18 @@
             </thead>
             <tbody>
               <tr ht-repeat="param in params">
-                <td class="name" nowrap>{{ param.name }}</td>
+                <td class="name" nowrap>
+                  <a id="{{ param.name }}"></a>
+                  {{ param.name }}
+                </td>
                 <td class="type"><span class="param-type">
                   {{ param.type && param.type.names.join(" | ") }}
                 </span></td>
-                <td class="description last">{{ param.description }}</td>
+                <td class="description last">
+                  <span ht-if="param.description">
+                    {{ param.description.replace(/\{@link (.*?)(#.*?)?\}/g, '<a href="$1.html$2">$1$2</a>') }}
+                  </span>
+                </td>
               </tr>
             </tbody>
           </table>
@@ -127,7 +134,7 @@
         <h3 class="subsection-title">Methods</h3>
         <dl ht-repeat="func in children.function">
           <dt>
-            <a href="{{ func.sourceUrl }}" class="name-link">
+            <a href="{{ func.sourceUrl }}" class="name-link" id="{{ func.name }}">
               <h4 class="name">
                 {{ func.name }}
                 <span ht-if="func.params" class="signature">({{ func.params.map(function(param){return param.name;}).join(", ") }})</span>
@@ -139,7 +146,9 @@
           </dt>
           <dd>
             <div class="description">
-              {{ func.description }}
+              <span ht-if="func.description">
+                {{ func.description.replace(/\{@link (.*?)(#.*?)?\}/g, '<a href="$1.html$2">$1$2</a>') }}
+              </span>
             </div>
             <div ht-if="func.examples && func.examples.length">
               <h5>Example</h5>
@@ -157,7 +166,11 @@
                     <td class="type"><span class="param-type">
                       {{ param.type && param.type.names.join(" | ").replace(new RegExp( String.fromCharCode(60), "g" ), "&lt;") }}
                     </span></td>
-                    <td class="description last">{{ param.description }}</td>
+                    <td class="description last">
+                      <span ht-if="param.description">
+                        {{ param.description.replace(/\{@link (.*?)(#.*?)?\}/g, '<a href="$1.html$2">$1$2</a>') }}
+                      </span>
+                    </td>
                   </tr>
                 </tbody>
               </table>
@@ -173,7 +186,11 @@
                     <td class="type"><span class="param-type">
                       {{ ret.type && ret.type.names.join(" | ").replace(new RegExp( String.fromCharCode(60), "g" ), "&lt;") }}
                     </span></td>
-                    <td class="description last">{{ ret.description }}</td>
+                    <td class="description last">
+                      <span ht-if="ret.description">
+                        {{ ret.description.replace(/\{@link (.*?)(#.*?)?\}/g, '<a href="$1.html$2">$1$2</a>') }}
+                      </span>
+                    </td>
                   </tr>
                 </tbody>
               </table>

--- a/angular-template/html/class.html
+++ b/angular-template/html/class.html
@@ -60,9 +60,11 @@
             <tbody>
               <tr ht-repeat="prop in properties">
                 <td class="name" nowrap>{{ prop.name }}</td>
-                <td class="type"><span class="param-type">
-                  {{ prop.type && prop.type.names.join(" | ") }}
-                </span></td>
+                <td class="type">
+                  <span class="param-type">
+                    {{ prop.typeDefinition }}
+                  </span>
+                </td>
                 <td class="description last">{{ prop.description }}</td>
               </tr>
             </tbody>

--- a/angular-template/html/class.html
+++ b/angular-template/html/class.html
@@ -78,9 +78,13 @@
               <tr ht-repeat="attr in attributes">
                 <td class="name" nowrap>{{ attr.name }}</td>
                 <td class="type"><span class="param-type">
-                  {{ attr.type && attr.type.names.join(" | ") }}
+                  {{ attr.typeDefinition }}
                 </span></td>
-                <td class="description last">{{ marked(attr.description||'') }}</td>
+                <td class="description last">
+                  <span ht-if="attr.description">
+                    {{ marked(attr.description.replace(/\{@link (.*?)(#.*?)?\}/g, '<a href="$1.html$2">$1$2</a>')||'') }}
+                  </span>
+                </td>
               </tr>
             </tbody>
           </table>
@@ -186,9 +190,11 @@
                 </thead>
                 <tbody>
                   <tr ht-repeat="ret in func.returns">
-                    <td class="type"><span class="param-type">
-                      {{ ret.type && ret.type.names.join(" | ").replace(new RegExp( String.fromCharCode(60), "g" ), "&lt;") }}
-                    </span></td>
+                    <td class="type">
+                      <span class="param-type">
+                        {{ ret.type && ret.type.names.join(" | ").replace(new RegExp( String.fromCharCode(60), "g" ), "&lt;") }}
+                      </span>
+                    </td>
                     <td class="description last">
                       <span ht-if="ret.description">
                         {{ ret.description.replace(/\{@link (.*?)(#.*?)?\}/g, '<a href="$1.html$2">$1$2</a>') }}

--- a/common/plugins/ngdoc.js
+++ b/common/plugins/ngdoc.js
@@ -147,12 +147,12 @@ function parseParamTypes(docletParams, tag) {
     }
 
     if (defaultTypes.indexOf(type[1].toLowerCase()) !== -1 || defaultTypeStarts.indexOf(type[1][0]) !== -1) {
-      parseTypeDefinitionUrl += type[1];
-      parseTypeDefinition += type[1];
+      parseTypeDefinitionUrl += type[1] + (type[2] || '');
     } else {
       parseTypeDefinitionUrl += '<a href="' + type[1] + '.html">' + type[1] + (type[2] || '') + '</a>';
-      parseTypeDefinition += type[1] + (type[2] || '');
     }
+
+    parseTypeDefinition += type[1] + (type[2] || '');
   }
 
   result.typeDefinitionUrl = parseTypeDefinitionUrl;

--- a/common/plugins/ngdoc.js
+++ b/common/plugins/ngdoc.js
@@ -22,6 +22,48 @@ exports.defineTags = function(dictionary) {
   })
   .synonym('attr');
 
+  dictionary.defineTag('param', {
+    mustHaveValue: true,
+    canHaveType: true,
+    canHaveName: true,
+    onTagged: function(doclet, tag) {
+      if (!doclet.params) {
+        doclet.params = [];
+      }
+
+      var defaultTypes = ['boolean', 'string', 'expression', '*', 'mixed', 'number', 'null', 'undefined', 'function',
+          '{}', 'object', '[]', 'array'];
+
+      var typeRegex = new RegExp(/\{(.*?[^\[\]])?(\[\])?\}.*?/);
+      var matches = typeRegex.exec(tag.text);
+
+      var types = matches[1].split('|');
+      matches[2] = (matches[2] || '');
+      var parsedTypeDefinition = '';
+
+      var i = 0;
+      for (; i < types.length; i++) {
+        var type = types[i];
+
+        if (i > 0) {
+          parsedTypeDefinition += '|';
+        }
+
+        if (defaultTypes.indexOf(type) !== -1 || type[0] === '"') {
+          parsedTypeDefinition += type + matches[2];
+        } else {
+          parsedTypeDefinition += '<a href="' + matches[1] + '.html">' + matches[1] + matches[2] + '</a>';
+        }
+      }
+
+      doclet.params.push({
+        typeDefinition: parsedTypeDefinition,
+        name: tag.value.name,
+        description: tag.value.description
+      });
+    }
+  });
+
   dictionary.defineTag('restrict', {
     mustHaveValue: true,
     onTagged: function(doclet, tag) {

--- a/common/plugins/ngdoc.js
+++ b/common/plugins/ngdoc.js
@@ -30,6 +30,15 @@ exports.defineTags = function(dictionary) {
     }
   });
 
+  dictionary.defineTag('property', {
+    mustHaveValue: true,
+    canHaveType: true,
+    canHaveName: true,
+    onTagged: function(doclet, tag) {
+      doclet.properties = parseParamTypes(doclet.properties, tag);
+    }
+  });
+
   dictionary.defineTag('restrict', {
     mustHaveValue: true,
     onTagged: function(doclet, tag) {

--- a/common/plugins/ngdoc.js
+++ b/common/plugins/ngdoc.js
@@ -59,22 +59,19 @@ exports.defineTags = function(dictionary) {
   });
 
   dictionary.defineTag('scope', {
-    onTagged: function(doclet, tag) {
-      var scopeType={
-        'object': '\'isolate\' scope',
-        '{}': '\'isolate\' scope',
-        'true': 'scope which prototypically inherits from its parent',
-        'false': 'shared scope'
-      }
-      var s = function() {
-        return scopeType[tag.value];
-      }();
-      if (!tag.value || !s) {
-        doclet.scopeType = 'scope';
+    onTagged: function (doclet, tag) {
+      var scopeType = {
+        'object': 'Creates a new isolated scope',
+        '{}': 'Creates a new isolated scope',
+        'true': 'Creates a new scope prototypically inheriting from its parent',
+        'false': 'Shares the scope of the parent'
+      };
+
+      if (!scopeType.hasOwnProperty(tag.value)) {
+        doclet.directiveScope = 'Creates a new scope';
       } else {
-        doclet.scopeType = s;
+        doclet.directiveScope = scopeType[tag.value];
       }
-      doclet.newScope = !(s == 'shared scope');
     }
-  });
+  })
 };

--- a/common/plugins/ngdoc.js
+++ b/common/plugins/ngdoc.js
@@ -59,19 +59,22 @@ exports.defineTags = function(dictionary) {
   });
 
   dictionary.defineTag('scope', {
-    onTagged: function (doclet, tag) {
-      var scopeType = {
-        'object': 'Creates a new isolated scope',
-        '{}': 'Creates a new isolated scope',
-        'true': 'Creates a new scope prototypically inheriting from its parent',
-        'false': 'Shares the scope of the parent'
-      };
-
-      if (!scopeType.hasOwnProperty(tag.value)) {
-        doclet.directiveScope = 'Creates a new scope';
-      } else {
-        doclet.directiveScope = scopeType[tag.value];
+    onTagged: function(doclet, tag) {
+      var scopeType={
+        'object': '\'isolate\' scope',
+        '{}': '\'isolate\' scope',
+        'true': 'scope which prototypically inherits from its parent',
+        'false': 'shared scope'
       }
+      var s = function() {
+        return scopeType[tag.value];
+      }();
+      if (!tag.value || !s) {
+        doclet.scopeType = 'scope';
+      } else {
+        doclet.scopeType = s;
+      }
+      doclet.newScope = !(s == 'shared scope');
     }
-  })
+  });
 };


### PR DESCRIPTION
This PR introduces enhanced support of what started with #59, some bug fixes and support to identify custom parameter types. In detail:

- It’s now possible to link to members. Using `{@link app.exampleDirective#exampleMember}` would link to the documentation using HTML anchors.
- Fix for `{@link}` parsing where only one match would be parsed, because regex was missing global modifier `\g`. This bug was introduced in #59.
- `{@link}` definition can now be parsed everywhere! Descriptions, parameters and attributes of directives, services and functions and ngDoc type definitions.
- Parameter types will now also be linked to their ngDoc type definition when the type is not a standard JavaScript type.
- Fix for function signatures where wrongly parsed “`Array.`” would be displayed as the return type. The `[]` syntax is now used, i.e. `CustomType[]` for an array of `CustomType`s.

![screen shot 2016-03-27 at 1 16 02 am](https://cloud.githubusercontent.com/assets/3391981/14063101/d0a561fc-f3b9-11e5-9d7e-6578df0b04da.png)
