### PR TITLE
Fix for #86

### DIFF
--- a/angular-template/html/layout.html
+++ b/angular-template/html/layout.html
@@ -80,7 +80,7 @@
 
         <!-- class files -->
         <div ht-if="!data.code && !data.readme">
-          <div ht-include="class.html"></div>
+          <div ht-include="'class.html'"></div>
         </div>
 
       </div>


### PR DESCRIPTION
This could be solved in angular-template, but since it's documentation mentions below format - I think it would be better to simply fix it here.
````
<div ht-include="'file.html'"></div>
````

Underlying problem is that generated template looks like this:
````
<div><%= htIncludeFunc(typeof class!=='undefined' && class && class.html ? class.html : 'class.html', data, {}) %></div>
````
Code that creates it is this: (https://github.com/allenhwkim/angular-template/blob/master/index.js#L87)
````
$(this).append("&lt;%= htIncludeFunc(typeof "+parts[0]+"!=='undefined' && "+expressions.join(' && ')+" ? "+expr+" : '"+expr.replace(/'/g,"\\'")+"', data, "+context+") %&gt;");
````

The above allows you to specify template dynamically (even in ht-repeat) and as you can see it is backwards compatible, but with an edge case when reserved words are used as properties. 