### PR TITLE
Allow @return to be used as a synonym of @returns

### DIFF
--- a/common/plugins/ngdoc.js
+++ b/common/plugins/ngdoc.js
@@ -44,7 +44,7 @@ exports.defineTags = function(dictionary) {
     canHaveType: true,
     canHaveName: false,
     onTagged: function(doclet, tag) {
-      var returnsText = new RegExp(/@returns (\{.*\}.*)/).exec(doclet.comment);
+      var returnsText = new RegExp(/@returns? (\{.*\}.*)/).exec(doclet.comment);
 
       if (returnsText) {
         tag.text = returnsText[1];


### PR DESCRIPTION
In vanilla JSDoc, `@return` is a synonym for `@returns`. Just made it work here as well.