### PR TITLE
Fix extra padding on param/prop description text

### DIFF
--- a/angular-template/css/site.css
+++ b/angular-template/css/site.css
@@ -307,14 +307,18 @@ section
 .params thead .last, .props thead .last { border-right: 1px solid #ddd; }
 
 .params td.description > p:first-child,
-.props td.description > p:first-child
+.props td.description > p:first-child,
+.params td.description span > p:first-child,
+.props td.description span > p:first-child
 {
     margin-top: 0;
     padding-top: 0;
 }
 
 .params td.description > p:last-child,
-.props td.description > p:last-child
+.props td.description > p:last-child,
+.params td.description span > p:last-child,
+.props td.description span > p:last-child
 {
     margin-bottom: 0;
     padding-bottom: 0;


### PR DESCRIPTION
This is necessary because decriptions are now wrapped in
```html
  <span ht-if="param.description">
    # description
  </span>
```