### PR TITLE
decode URI before writing filename

### DIFF
--- a/angular-template/publish.js
+++ b/angular-template/publish.js
@@ -290,7 +290,7 @@ exports.publish = function(data, opts, tutorials) {
 
   // generate jsdoc html files
   classes.forEach(function(doclet) {
-    var jsDocPath = doclet.jsDocUrl.replace(/#.*$/,'');
+    var jsDocPath = decodeURIComponent(doclet.jsDocUrl.replace(/#.*$/,''));
     var outputPath = path.join(outdir, jsDocPath);
     doclet.nav = nav;
     generate(outputPath, doclet);


### PR DESCRIPTION
If we URI-encode any spaces or characters in a class name, those entities need to be decoded before they are written to the filesystem. 

For example, `Hello%20World.js` is a valid value for `doclet.jsDocUrl`, but needs to be stored in the filesystem as `Hello World.js`.