### PR TITLE
update depency (jsdoc)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "angular-template": "^2.0.7",
     "js-template": "~0.1.3",
-    "jsdoc": "3.3.2",
+    "jsdoc": "^3.4.1",
     "marked": "^0.3.5",
     "q": "^1.4.1"
   },


### PR DESCRIPTION
fix: jsdoc 3.3.2 is deprecated #100