### PR TITLE
Fix path for directive path html templates

### DIFF
--- a/angular-template/publish.js
+++ b/angular-template/publish.js
@@ -230,7 +230,7 @@ exports.publish = function(data, opts, tutorials) {
         var templateCode =  {
           name: doclet.name,
           longname: doclet.longname,
-          filePath: templatePath,
+          filePath: path.join(doclet.meta.path, doclet.meta.filename),
           templateUrl: templateUrl,
           outputName: templateUrl.replace(/[\/\\]/g,'_')
         };


### PR DESCRIPTION
Fix for directive path html templates. I think filePath must be abolute.
May be related with issue https://github.com/allenhwkim/angular-jsdoc/issues/92